### PR TITLE
Added AbstractBackend

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ import ufl
 from functools import partial
 
 from firedrake_numpy import evaluate_primal, evaluate_vjp
-from firedrake_numpy import firedrake_to_numpy, numpy_to_firedrake
+from firedrake_numpy import from_numpy
 
 # Create mesh for the unit square domain
 n = 10
@@ -46,7 +46,7 @@ numpy_firedrake_solve = partial(evaluate_primal, firedrake_solve, templates)
 # Let's create a vector of ones with size equal to the number of cells in the mesh
 f = np.ones(W.dim())
 u = numpy_firedrake_solve(f)[0] # u is a NumPy array now
-u_firedrake = numpy_to_firedrake(u, firedrake.Function(V)) # we need to explicitly provide template function for conversion
+u_firedrake = from_numpy(u, firedrake.Function(V)) # we need to explicitly provide template function for conversion
 
 # Now let's evaluate the vector-Jacobian product
 numpy_output, firedrake_output, firedrake_inputs, tape = numpy_firedrake_solve(f)

--- a/codecov.yml
+++ b/codecov.yml
@@ -13,3 +13,4 @@ coverage:
                                #   option: "X%" a static target percentage to hit
         threshold: 100        # allowed to drop X% and still result in a "success" commit status
         if_ci_failed: error    # if ci fails report status as success, error, or failure
+    patch: off

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,3 +3,13 @@ coverage:
   precision: 2
   round: down
   range: "1...100"
+
+  status:
+    project:                   # measuring the overall project coverage
+      default:                 # This can be anything, but it needs to exist as the name
+        enabled: yes           # must be yes|true to enable this status
+        target: 1           # specify the target coverage for each commit status
+                               #   option: "auto" (must increase from parent commit or pull request base)
+                               #   option: "X%" a static target percentage to hit
+        threshold: 100        # allowed to drop X% and still result in a "success" commit status
+        if_ci_failed: error    # if ci fails report status as success, error, or failure

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,1 +1,5 @@
 comment: false
+coverage:
+  precision: 2
+  round: down
+  range: "1...100"

--- a/firedrake_numpy/__init__.py
+++ b/firedrake_numpy/__init__.py
@@ -1,2 +1,2 @@
-from .helpers import firedrake_to_numpy, numpy_to_firedrake
+from .helpers import to_numpy, from_numpy
 from .core import evaluate_primal, evaluate_vjp, evaluate_jvp

--- a/firedrake_numpy/_backends.py
+++ b/firedrake_numpy/_backends.py
@@ -1,0 +1,198 @@
+# The backends pattern was borrowed from einops package
+# https://github.com/arogozhnikov/einops/blob/7a1bfb8738d33bdba3fa94de713814c0b2848c59/einops/_backends.py
+"""
+Backends in `numpy-fem-adjoint` are organized to meet the following requirements
+- backends are not imported unless those are actually needed, because
+    - backends may not be installed
+    - importing all available backends will drive to significant memory footprint
+    - backends may by present but installed with errors (but never used),
+      importing may drive to crashes
+- backend should be either symbolic or imperative (tensorflow is for both, but that causes problems)
+    - this determines which methods (from_numpy/to_numpy or create_symbol/eval_symbol) should be defined
+- if backend can't (temporarily) provide symbols for shape dimensions, UnknownSize objects are used
+"""
+
+import sys
+from typing import Collection
+from dataclasses import dataclass
+import pyadjoint
+import numpy as np
+
+_backends = {}
+_debug_importing = False
+
+
+@dataclass
+class BackendVariable:
+    block_variable: pyadjoint.block_variable.BlockVariable
+
+
+class AbstractBackend:
+    """Base backend class, major part of methods are only for debugging purposes. """
+
+    framework_name: str
+
+    def is_appropriate_type(self, tensor):
+        """ helper method should recognize fem variables it can handle """
+        raise NotImplementedError()
+
+    def to_numpy(self, x):
+        raise NotImplementedError()
+
+    def from_numpy(self, x, template):
+        raise NotImplementedError()
+
+    def __repr__(self):
+        return "<numpy-fem-adjoint backend for {}>".format(self.framework_name)
+
+
+def get_backend(fem_variable) -> AbstractBackend:
+    """
+    Takes a correct backend (e.g. Firedrake backend if Function is firedrake.Function) for a fem variable.
+    If needed, imports package and creates backend
+    """
+    for framework_name, backend in _backends.items():
+        if backend.is_appropriate_type(fem_variable):
+            return backend
+
+    # Find backend subclasses recursively
+    backend_subclasses = []
+    backends = AbstractBackend.__subclasses__()
+    while backends:
+        backend = backends.pop()
+        backends += backend.__subclasses__()
+        backend_subclasses.append(backend)
+
+    for BackendSubclass in backend_subclasses:
+        if _debug_importing:
+            print("Testing for subclass of ", BackendSubclass)
+        if BackendSubclass.framework_name not in _backends:
+            # check that module was already imported. Otherwise it can't be imported
+            if BackendSubclass.framework_name in sys.modules:
+                if _debug_importing:
+                    print("Imported backend for ", BackendSubclass.framework_name)
+                backend = BackendSubclass()
+                _backends[backend.framework_name] = backend
+                if backend.is_appropriate_type(fem_variable):
+                    return backend
+
+    raise RuntimeError(
+        "Type unknown to numpy-fem-adjoint {}".format(type(fem_variable))
+    )
+
+
+class FiredrakeBackend(AbstractBackend):
+    framework_name = "firedrake"
+
+    def __init__(self):
+        import firedrake
+
+        self.firedrake = firedrake
+
+    def is_appropriate_type(self, fem_variable):
+        if isinstance(fem_variable, self.firedrake.Constant):
+            return True
+        if isinstance(fem_variable, self.firedrake.Function):
+            return True
+        if isinstance(fem_variable, self.firedrake.Vector):
+            return True
+        return False
+
+    def to_numpy(self, firedrake_var):
+        """Convert Firedrake variable to NumPy array.
+        Serializes the input so that all MPI ranks have the same data."""
+        if isinstance(firedrake_var, self.firedrake.Constant):
+            return np.asarray(firedrake_var.values())
+
+        if isinstance(firedrake_var, self.firedrake.Function):
+            vec = firedrake_var.vector()
+            data = vec.gather()
+            return np.asarray(data)
+
+        if isinstance(firedrake_var, self.firedrake.Vector):
+            data = firedrake_var.gather()
+            return np.asarray(data)
+
+        raise ValueError("Cannot convert " + str(type(firedrake_var)))
+
+    def from_numpy(self, numpy_array, firedrake_var_template):
+        """Convert numpy array to Firedrake variable.
+        Distributes the input array across MPI ranks.
+        Input:
+            numpy_array (np.array): NumPy array to be converted to Firedrake type
+            firedrake_var_template (FiredrakeVariable): Templates for converting arrays to Firedrake type
+        Output:
+            fenucs_output (FiredrakeVariable): Firedrake representation of the input numpy_array
+        """
+
+        if isinstance(firedrake_var_template, self.firedrake.Constant):
+            if numpy_array.shape == (1,):
+                return type(firedrake_var_template)(numpy_array[0])
+            else:
+                return type(firedrake_var_template)(numpy_array)
+
+        if isinstance(firedrake_var_template, self.firedrake.Function):
+            function_space = firedrake_var_template.function_space()
+
+            u = type(firedrake_var_template)(function_space)
+
+            # assume that given numpy array is global array that needs to be distrubuted across processes
+            # when Firedrake function is created
+            firedrake_size = u.vector().size()
+            np_size = numpy_array.size
+
+            if np_size != firedrake_size:
+                err_msg = (
+                    f"Cannot convert numpy array to Function:"
+                    f"Wrong size {numpy_array.size} vs {u.vector().size()}"
+                )
+                raise ValueError(err_msg)
+
+            if numpy_array.dtype != np.float_:
+                err_msg = (
+                    f"The numpy array must be of type {np.float_}, "
+                    "but got {numpy_array.dtype}"
+                )
+                raise ValueError(err_msg)
+
+            range_begin, range_end = u.vector().local_range()
+            numpy_array = np.asarray(numpy_array)
+            local_array = numpy_array.reshape(firedrake_size)[range_begin:range_end]
+            # TODO: replace with a Firedrake-way of setting local portion of data (probably u.dat.data)
+            u.vector().set_local(local_array)
+            u.vector().apply("insert")
+            return u
+
+        err_msg = f"Cannot convert numpy array to {firedrake_var_template}"
+        raise ValueError(err_msg)
+
+
+class PyadjointBackend(AbstractBackend):
+    framework_name = "pyadjoint"
+
+    def __init__(self):
+        import pyadjoint
+
+        self.pyadjoint = pyadjoint
+
+    def is_appropriate_type(self, fem_variable):
+        return isinstance(fem_variable, (self.pyadjoint.AdjFloat, float))
+
+    def to_numpy(self, pyadjoint_var):
+        """Convert pyadjoint float variable to NumPy array."""
+        if isinstance(pyadjoint_var, (self.pyadjoint.AdjFloat, float)):
+            return np.asarray(pyadjoint_var)
+        raise ValueError("Cannot convert " + str(type(pyadjoint_var)))
+
+    def from_numpy(self, numpy_array, pyadjoint_var_template):
+        """Convert scalar numpy array to float that pyadjoint understands.
+        Input:
+            numpy_array (np.array): NumPy array to be converted to pyadjoint type
+            pyadjoint_var_template (PyadjointVariable): Templates for converting arrays to pyadjoint type
+        Output:
+            (FiredrakeVariable): pyadjoint representation of the input numpy_array
+        """
+        if isinstance(pyadjoint_var_template, self.pyadjoint.AdjFloat):
+            return float(numpy_array)
+        err_msg = f"Cannot convert numpy array to {pyadjoint_var_template}"
+        raise ValueError(err_msg)

--- a/firedrake_numpy/helpers.py
+++ b/firedrake_numpy/helpers.py
@@ -1,106 +1,43 @@
-import firedrake
-import pyadjoint
 import numpy as np
-
 import warnings
-
-from typing import Type, List, Union, Iterable, Callable, Tuple
-
-FiredrakeVariable = Union[firedrake.Constant, firedrake.Function, pyadjoint.AdjFloat]
+from typing import Collection
+from ._backends import get_backend, BackendVariable
 
 
-def firedrake_to_numpy(firedrake_var: FiredrakeVariable) -> np.array:
-    """Convert Firedrake variable to NumPy array.
+def to_numpy(fem_variable: BackendVariable) -> np.array:
+    """Convert fem_variable to NumPy array.
     Serializes the input so that all MPI ranks have the same data."""
-    if isinstance(firedrake_var, firedrake.Constant):
-        return np.asarray(firedrake_var.values())
-
-    if isinstance(firedrake_var, firedrake.Function):
-        vec = firedrake_var.vector()
-        data = vec.gather()
-        return np.asarray(data)
-
-    if isinstance(firedrake_var, firedrake.Vector):
-        data = firedrake_var.gather()
-        return np.asarray(data)
-
-    if isinstance(firedrake_var, (pyadjoint.AdjFloat, float)):
-        return np.asarray(firedrake_var)
-
-    raise ValueError("Cannot convert " + str(type(firedrake_var)))
+    backend = get_backend(fem_variable)
+    return backend.to_numpy(fem_variable)
 
 
-def numpy_to_firedrake(
-    numpy_array: np.array, firedrake_var_template: FiredrakeVariable
-) -> FiredrakeVariable:  # noqa: C901
-    """Convert numpy array to Firedrake variable.
+def from_numpy(numpy_array: np.array, backend_var_template: BackendVariable):
+    """Convert NumPy array to Firedrake variable.
     Distributes the input array across MPI ranks.
     Input:
-        numpy_array (np.array): NumPy array to be converted to Firedrake type
-        firedrake_var_template (FiredrakeVariable): Templates for converting arrays to Firedrake type
+        numpy_array (np.array): NumPy array to be converted to FEM backend type
+        backend_var_template (BackendVariable): Templates for converting arrays to FEM backend type
     Output:
-        fenucs_output (FiredrakeVariable): Firedrake representation of the input numpy_array
+        (BackendVariable): FEM backend representation of the input numpy_array
     """
-
-    if isinstance(firedrake_var_template, firedrake.Constant):
-        if numpy_array.shape == (1,):
-            return type(firedrake_var_template)(numpy_array[0])
-        else:
-            return type(firedrake_var_template)(numpy_array)
-
-    if isinstance(firedrake_var_template, firedrake.Function):
-        function_space = firedrake_var_template.function_space()
-
-        u = type(firedrake_var_template)(function_space)
-
-        # assume that given numpy array is global array that needs to be distrubuted across processes
-        # when Firedrake function is created
-        firedrake_size = u.vector().size()
-        np_size = numpy_array.size
-
-        if np_size != firedrake_size:
-            err_msg = (
-                f"Cannot convert numpy array to Function:"
-                f"Wrong size {numpy_array.size} vs {u.vector().size()}"
-            )
-            raise ValueError(err_msg)
-
-        if numpy_array.dtype != np.float_:
-            err_msg = (
-                f"The numpy array must be of type {np.float_}, "
-                "but got {numpy_array.dtype}"
-            )
-            raise ValueError(err_msg)
-
-        range_begin, range_end = u.vector().local_range()
-        numpy_array = np.asarray(numpy_array)
-        local_array = numpy_array.reshape(firedrake_size)[range_begin:range_end]
-        # TODO: replace with a Firedrake-way of setting local portion of data (probably u.dat.data)
-        u.vector().set_local(local_array)
-        u.vector().apply("insert")
-        return u
-
-    if isinstance(firedrake_var_template, pyadjoint.AdjFloat):
-        return float(numpy_array)
-
-    err_msg = f"Cannot convert numpy array to {firedrake_var_template}"
-    raise ValueError(err_msg)
+    backend = get_backend(backend_var_template)
+    return backend.from_numpy(numpy_array, backend_var_template)
 
 
 def get_numpy_input_templates(
-    firedrake_input_templates: Iterable[FiredrakeVariable],
-) -> List[np.array]:
-    """Returns a list of numpy representations of the input templates"""
-    numpy_input_templates = [firedrake_to_numpy(x) for x in firedrake_input_templates]
+    backend_input_templates: Collection[BackendVariable],
+) -> Collection[np.array]:
+    """Returns a collection of numpy representations of the input templates"""
+    numpy_input_templates = [to_numpy(x) for x in backend_input_templates]
     return numpy_input_templates
 
 
 def check_input(
-    firedrake_templates: FiredrakeVariable, *args: FiredrakeVariable
+    backend_templates: Collection[BackendVariable], *args: np.array
 ) -> None:
     """Checks that the number of inputs arguments is correct"""
     n_args = len(args)
-    expected_nargs = len(firedrake_templates)
+    expected_nargs = len(backend_templates)
     if n_args != expected_nargs:
         raise ValueError(
             "Wrong number of arguments"
@@ -108,7 +45,7 @@ def check_input(
         )
 
     # Check that each input argument has correct dimensions
-    numpy_templates = get_numpy_input_templates(firedrake_templates)
+    numpy_templates = get_numpy_input_templates(backend_templates)
     for i, (arg, template) in enumerate(zip(args, numpy_templates)):
         if arg.shape != template.shape:
             raise ValueError(
@@ -125,11 +62,11 @@ def check_input(
             )
 
 
-def convert_all_to_firedrake(
-    firedrake_templates: Iterable[FiredrakeVariable], *args: np.array
-) -> Iterable[FiredrakeVariable]:
-    """Converts input array to corresponding Firedrake variables"""
-    firedrake_inputs = []
-    for inp, template in zip(args, firedrake_templates):
-        firedrake_inputs.append(numpy_to_firedrake(inp, template))
-    return firedrake_inputs
+def convert_all_to_backend(
+    backend_templates: Collection[BackendVariable], *args: np.array
+) -> Collection[BackendVariable]:
+    """Converts input array to corresponding backend variables"""
+    backend_inputs = []
+    for inp, template in zip(args, backend_templates):
+        backend_inputs.append(from_numpy(inp, template))
+    return backend_inputs

--- a/tests/test_assemble.py
+++ b/tests/test_assemble.py
@@ -8,7 +8,6 @@ import ufl
 import fdm
 
 from firedrake_numpy import evaluate_primal, evaluate_vjp, evaluate_jvp
-from firedrake_numpy import firedrake_to_numpy, numpy_to_firedrake
 
 
 mesh = firedrake.UnitSquareMesh(3, 2)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -2,7 +2,7 @@ import pytest
 
 import firedrake
 import numpy
-from firedrake_numpy import firedrake_to_numpy, numpy_to_firedrake
+from firedrake_numpy import to_numpy, from_numpy
 
 
 @pytest.mark.parametrize(
@@ -13,7 +13,7 @@ from firedrake_numpy import firedrake_to_numpy, numpy_to_firedrake
     ],
 )
 def test_firedrake_to_numpy_constant(test_input, expected):
-    assert numpy.allclose(firedrake_to_numpy(test_input), expected)
+    assert numpy.allclose(to_numpy(test_input), expected)
 
 
 def test_firedrake_to_numpy_function():
@@ -23,7 +23,7 @@ def test_firedrake_to_numpy_function():
     x = firedrake.SpatialCoordinate(mesh)
     test_input = firedrake.interpolate(x[0], V)
     expected = numpy.linspace(0.05, 0.95, num=10)
-    assert numpy.allclose(firedrake_to_numpy(test_input), expected)
+    assert numpy.allclose(to_numpy(test_input), expected)
 
 
 def test_firedrake_to_numpy_mixed_function():
@@ -35,7 +35,7 @@ def test_firedrake_to_numpy_mixed_function():
     test_input = firedrake.interpolate(firedrake.as_vector(vec_dim * (x[0],)), V)
     expected = numpy.linspace(0.05, 0.95, num=10)
     expected = numpy.reshape(numpy.tile(expected, (4, 1)).T, V.dim())
-    assert numpy.allclose(firedrake_to_numpy(test_input), expected)
+    assert numpy.allclose(to_numpy(test_input), expected)
 
 
 def test_firedrake_to_numpy_vector():
@@ -46,7 +46,7 @@ def test_firedrake_to_numpy_vector():
     test_input = firedrake.interpolate(x[0], V)
     test_input_vector = test_input.vector()
     expected = numpy.linspace(0.05, 0.95, num=10)
-    assert numpy.allclose(firedrake_to_numpy(test_input_vector), expected)
+    assert numpy.allclose(to_numpy(test_input_vector), expected)
 
 
 @pytest.mark.parametrize(
@@ -57,7 +57,7 @@ def test_firedrake_to_numpy_vector():
     ],
 )
 def test_numpy_to_firedrake_constant(test_input, expected):
-    firedrake_test_input = numpy_to_firedrake(test_input, firedrake.Constant(0.0))
+    firedrake_test_input = from_numpy(test_input, firedrake.Constant(0.0))
     assert numpy.allclose(firedrake_test_input.values(), expected.values())
 
 
@@ -66,7 +66,7 @@ def test_numpy_to_firedrake_function():
     mesh = firedrake.UnitIntervalMesh(10)
     V = firedrake.FunctionSpace(mesh, "DG", 0)
     template = firedrake.Function(V)
-    firedrake_test_input = numpy_to_firedrake(test_input, template)
+    firedrake_test_input = from_numpy(test_input, template)
     x = firedrake.SpatialCoordinate(mesh)
     expected = firedrake.interpolate(x[0], V)
     assert numpy.allclose(

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -9,7 +9,7 @@ import ufl
 import fdm
 
 from firedrake_numpy import evaluate_primal, evaluate_vjp, evaluate_jvp
-from firedrake_numpy import firedrake_to_numpy, numpy_to_firedrake
+from firedrake_numpy import to_numpy
 
 mesh = firedrake.UnitSquareMesh(6, 5)
 V = firedrake.FunctionSpace(mesh, "P", 1)
@@ -38,7 +38,7 @@ inputs = (np.ones(1) * 0.5, np.ones(1) * 0.6)
 def test_firedrake_forward():
     numpy_output, _, _, _ = evaluate_primal(solve_firedrake, templates, *inputs)
     u = solve_firedrake(firedrake.Constant(0.5), firedrake.Constant(0.6))
-    assert np.allclose(numpy_output, firedrake_to_numpy(u))
+    assert np.allclose(numpy_output, to_numpy(u))
 
 
 def test_firedrake_vjp():


### PR DESCRIPTION
This PR adds `AbstractBackend` and rewrites existing Firedrake-specific functions under the subclass of `AbstractBackend`.
This is an attempt to generalize the interface to support Firedrake and FEniCS simultaneously.
FEniCS support will be added later based on https://github.com/IvanYashchuk/numpy-fenics-adjoint.