### PR TITLE
Renamed jvp, vjp to pushforward and pullback

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ numpy_output, firedrake_output, firedrake_inputs, tape = numpy_firedrake_solve(f
 g = np.ones_like(numpy_output)
 
 # `vjp_out` is the result of (implicitly) multiplying the vector `g` with the solution Jacobian du/df
-vjp_out = evaluate_pullback(g, firedrake_output, firedrake_inputs, tape)
+vjp_out = evaluate_pullback(firedrake_output, firedrake_inputs, tape, g)
 ```
 
 Check the `tests/` folder for the additional usage examples.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ import ufl
 
 from functools import partial
 
-from firedrake_numpy import evaluate_primal, evaluate_vjp
+from firedrake_numpy import evaluate_primal, evaluate_pullback
 from firedrake_numpy import from_numpy
 
 # Create mesh for the unit square domain
@@ -68,7 +68,7 @@ numpy_output, firedrake_output, firedrake_inputs, tape = numpy_firedrake_solve(f
 g = np.ones_like(numpy_output)
 
 # `vjp_out` is the result of (implicitly) multiplying the vector `g` with the solution Jacobian du/df
-vjp_out = evaluate_vjp(g, firedrake_output, firedrake_inputs, tape)
+vjp_out = evaluate_pullback(g, firedrake_output, firedrake_inputs, tape)
 ```
 
 Check the `tests/` folder for the additional usage examples.

--- a/firedrake_numpy/__init__.py
+++ b/firedrake_numpy/__init__.py
@@ -1,2 +1,2 @@
 from .helpers import to_numpy, from_numpy
-from .core import evaluate_primal, evaluate_pullback, evaluate_jvp
+from .core import evaluate_primal, evaluate_pullback, evaluate_pushforward

--- a/firedrake_numpy/__init__.py
+++ b/firedrake_numpy/__init__.py
@@ -1,2 +1,2 @@
 from .helpers import to_numpy, from_numpy
-from .core import evaluate_primal, evaluate_vjp, evaluate_jvp
+from .core import evaluate_primal, evaluate_pullback, evaluate_jvp

--- a/firedrake_numpy/core.py
+++ b/firedrake_numpy/core.py
@@ -54,25 +54,27 @@ def evaluate_primal(
 # Here dx is used for the output of a propagator since ∂x is not a valid name for python variables
 
 
-def evaluate_vjp(
-    dnumpy_output: np.array,
+def evaluate_pullback(
+    Δnumpy_output: np.array,
     firedrake_output: BackendVariable,
     firedrake_inputs: Collection[BackendVariable],
     tape: pyadjoint.Tape,
 ) -> Collection[np.array]:
-    """Computes the gradients of the output with respect to the inputs.
+    """Pullback is a function to propagate the derivative information from outputs to inputs.
+    It also corresponds to evaluating a Jacobian transpose vector product or vector Jacobian product.
+    This is a reverse-mode automatic differentiation.
     Input:
-        Δfiredrake_output (np.array): NumPy array representation of the tangent covector to multiply transposed jacobian with
+        Δnumpy_output (np.array): NumPy array representation of the tangent covector to multiply transposed Jacobian with
         firedrake_output (AdjFloat or Function): Firedrake representation of the output from firedrake_function(*firedrake_inputs)
         firedrake_inputs (collection of BackendVariable): Firedrake representation of the input args
         tape (pyadjoint.Tape): pyadjoint's saved computational graph
     Output:
         dnumpy_inputs (collection of np.array):
-            NumPy array representation of the `Δfiredrake_output` times jacobian
+            NumPy array representation of the `Δnumpy_output` times Jacobian
             of firedrake_function(*firedrake_inputs) wrt to every firedrake_input
     """
     # Convert tangent covector (adjoint variable) to a backend variable
-    Δfiredrake_output = from_numpy(dnumpy_output, firedrake_output)
+    Δfiredrake_output = from_numpy(Δnumpy_output, firedrake_output)
 
     # pyadjoint doesn't allow setting Functions to block_variable.adj_value
     backend = get_backend(firedrake_inputs[0])

--- a/firedrake_numpy/core.py
+++ b/firedrake_numpy/core.py
@@ -55,19 +55,19 @@ def evaluate_primal(
 
 
 def evaluate_pullback(
-    Δnumpy_output: np.array,
     firedrake_output: BackendVariable,
     firedrake_inputs: Collection[BackendVariable],
     tape: pyadjoint.Tape,
+    Δnumpy_output: np.array,
 ) -> Collection[np.array]:
     """Pullback is a function to propagate the derivative information from outputs to inputs.
     It also corresponds to evaluating a Jacobian transpose vector product or vector Jacobian product.
     This is a reverse-mode automatic differentiation.
     Input:
-        Δnumpy_output (np.array): NumPy array representation of the tangent covector to multiply transposed Jacobian with
         firedrake_output (AdjFloat or Function): Firedrake representation of the output from firedrake_function(*firedrake_inputs)
         firedrake_inputs (collection of BackendVariable): Firedrake representation of the input args
         tape (pyadjoint.Tape): pyadjoint's saved computational graph
+        Δnumpy_output (np.array): NumPy array representation of the tangent covector to multiply transposed Jacobian with
     Output:
         dnumpy_inputs (collection of np.array):
             NumPy array representation of the `Δnumpy_output` times Jacobian
@@ -96,19 +96,19 @@ def evaluate_pullback(
 
 
 def evaluate_pushforward(
-    Δnumpy_inputs: Collection[np.array],
     firedrake_output: BackendVariable,
     firedrake_inputs: Collection[BackendVariable],
     tape: pyadjoint.Tape,
+    Δnumpy_inputs: Collection[np.array],
 ) -> Collection[np.array]:
     """Pushforward is a function to propagate the derivative information from inputs to outputs.
     It also corresponds to evaluating a Jacobian vector product.
     This is a forward-mode automatic differentiation.
     Input:
-        Δnumpy_inputs (collection of np.array): NumPy array representation of the tangent vector to multiply with Jacobian
         firedrake_output (AdjFloat or Function): Firedrake representation of the output from firedrake_function(*firedrake_inputs)
         firedrake_inputs (collection of BackendVariable): Firedrake representation of the input args
         tape (pyadjoint.Tape): pyadjoint's saved computational graph
+        Δnumpy_inputs (collection of np.array): NumPy array representation of the tangent vector to multiply with Jacobian
     Output:
         dnumpy_output (np.array):
             NumPy array representation of the `Δnumpy_inputs` times Jacobian

--- a/firedrake_numpy/core.py
+++ b/firedrake_numpy/core.py
@@ -95,19 +95,25 @@ def evaluate_pullback(
     return dnumpy_inputs
 
 
-def evaluate_jvp(
-    firedrake_function: Callable,
-    firedrake_templates: Collection[BackendVariable],
-    numpy_inputs: Collection[np.array],
+def evaluate_pushforward(
     Δnumpy_inputs: Collection[np.array],
+    firedrake_output: BackendVariable,
+    firedrake_inputs: Collection[BackendVariable],
+    tape: pyadjoint.Tape,
 ) -> Collection[np.array]:
-    """Computes the primal Firedrake function together with the corresponding tangent linear model.
-    Note that Δnumpy_inputs are sometimes referred to as tangent vectors.
+    """Pushforward is a function to propagate the derivative information from inputs to outputs.
+    It also corresponds to evaluating a Jacobian vector product.
+    This is a forward-mode automatic differentiation.
+    Input:
+        Δnumpy_inputs (collection of np.array): NumPy array representation of the tangent vector to multiply with Jacobian
+        firedrake_output (AdjFloat or Function): Firedrake representation of the output from firedrake_function(*firedrake_inputs)
+        firedrake_inputs (collection of BackendVariable): Firedrake representation of the input args
+        tape (pyadjoint.Tape): pyadjoint's saved computational graph
+    Output:
+        dnumpy_output (np.array):
+            NumPy array representation of the `Δnumpy_inputs` times Jacobian
+            of firedrake_function(*firedrake_inputs) wrt to every firedrake_input
     """
-
-    numpy_output, firedrake_output, firedrake_inputs, tape = evaluate_primal(
-        firedrake_function, firedrake_templates, *numpy_inputs
-    )
 
     # Now tangent (pushforward) evaluation!
     tape.reset_variables()
@@ -121,4 +127,4 @@ def evaluate_jvp(
     dfiredrake_output = firedrake_output.block_variable.tlm_value
     dnumpy_output = to_numpy(dfiredrake_output)
 
-    return numpy_output, dnumpy_output
+    return dnumpy_output

--- a/tests/fenics_backend/test_assemble.py
+++ b/tests/fenics_backend/test_assemble.py
@@ -46,7 +46,7 @@ def test_vjp_assemble_eval():
         assemble_fenics, templates, *inputs
     )
     g = np.ones_like(numpy_output)
-    vjp_out = evaluate_pullback(g, fenics_output, fenics_inputs, tape)
+    vjp_out = evaluate_pullback(fenics_output, fenics_inputs, tape, g)
 
     fdm_jac0 = fdm.jacobian(ff0)(inputs[0])
     fdm_jac1 = fdm.jacobian(ff1)(inputs[1])
@@ -72,6 +72,6 @@ def test_jvp_assemble_eval():
     _, fenics_output, fenics_inputs, tape = evaluate_primal(
         assemble_fenics, templates, *inputs
     )
-    out_tangent = evaluate_pushforward(tangents, fenics_output, fenics_inputs, tape)
+    out_tangent = evaluate_pushforward(fenics_output, fenics_inputs, tape, tangents)
 
     assert np.allclose(fdm_jvp0 + fdm_jvp1 + fdm_jvp2, out_tangent)

--- a/tests/fenics_backend/test_assemble.py
+++ b/tests/fenics_backend/test_assemble.py
@@ -7,7 +7,7 @@ import ufl
 
 import fdm
 
-from firedrake_numpy import evaluate_primal, evaluate_pullback, evaluate_jvp
+from firedrake_numpy import evaluate_primal, evaluate_pullback, evaluate_pushforward
 
 
 mesh = fa.UnitSquareMesh(3, 2)
@@ -69,6 +69,9 @@ def test_jvp_assemble_eval():
     fdm_jvp1 = fdm.jvp(ff1, tangents[1])(primals[1])
     fdm_jvp2 = fdm.jvp(ff2, tangents[2])(primals[2])
 
-    _, out_tangent = evaluate_jvp(assemble_fenics, templates, primals, tangents)
+    _, fenics_output, fenics_inputs, tape = evaluate_primal(
+        assemble_fenics, templates, *inputs
+    )
+    out_tangent = evaluate_pushforward(tangents, fenics_output, fenics_inputs, tape)
 
     assert np.allclose(fdm_jvp0 + fdm_jvp1 + fdm_jvp2, out_tangent)

--- a/tests/fenics_backend/test_assemble.py
+++ b/tests/fenics_backend/test_assemble.py
@@ -7,7 +7,7 @@ import ufl
 
 import fdm
 
-from firedrake_numpy import evaluate_primal, evaluate_vjp, evaluate_jvp
+from firedrake_numpy import evaluate_primal, evaluate_pullback, evaluate_jvp
 
 
 mesh = fa.UnitSquareMesh(3, 2)
@@ -46,7 +46,7 @@ def test_vjp_assemble_eval():
         assemble_fenics, templates, *inputs
     )
     g = np.ones_like(numpy_output)
-    vjp_out = evaluate_vjp(g, fenics_output, fenics_inputs, tape)
+    vjp_out = evaluate_pullback(g, fenics_output, fenics_inputs, tape)
 
     fdm_jac0 = fdm.jacobian(ff0)(inputs[0])
     fdm_jac1 = fdm.jacobian(ff1)(inputs[1])

--- a/tests/fenics_backend/test_solve.py
+++ b/tests/fenics_backend/test_solve.py
@@ -8,7 +8,7 @@ import ufl
 
 import fdm
 
-from firedrake_numpy import evaluate_primal, evaluate_vjp, evaluate_jvp
+from firedrake_numpy import evaluate_primal, evaluate_pullback, evaluate_jvp
 from firedrake_numpy import to_numpy
 
 mesh = fa.UnitSquareMesh(6, 5)
@@ -47,7 +47,7 @@ def test_fenics_vjp():
         solve_fenics, templates, *inputs
     )
     g = np.ones_like(numpy_output)
-    vjp_out = evaluate_vjp(g, fenics_output, fenics_inputs, tape)
+    vjp_out = evaluate_pullback(g, fenics_output, fenics_inputs, tape)
     check1 = np.isclose(vjp_out[0], np.asarray(-2.91792642))
     check2 = np.isclose(vjp_out[1], np.asarray(2.43160535))
     assert check1 and check2

--- a/tests/fenics_backend/test_solve.py
+++ b/tests/fenics_backend/test_solve.py
@@ -47,7 +47,7 @@ def test_fenics_vjp():
         solve_fenics, templates, *inputs
     )
     g = np.ones_like(numpy_output)
-    vjp_out = evaluate_pullback(g, fenics_output, fenics_inputs, tape)
+    vjp_out = evaluate_pullback(fenics_output, fenics_inputs, tape, g)
     check1 = np.isclose(vjp_out[0], np.asarray(-2.91792642))
     check2 = np.isclose(vjp_out[1], np.asarray(2.43160535))
     assert check1 and check2
@@ -68,6 +68,6 @@ def test_fenics_jvp():
     _, fenics_output, fenics_inputs, tape = evaluate_primal(
         solve_fenics, templates, *inputs
     )
-    out_tangent = evaluate_pushforward(tangents, fenics_output, fenics_inputs, tape)
+    out_tangent = evaluate_pushforward(fenics_output, fenics_inputs, tape, tangents)
 
     assert np.allclose(fdm_jvp0 + fdm_jvp1, out_tangent)

--- a/tests/fenics_backend/test_solve.py
+++ b/tests/fenics_backend/test_solve.py
@@ -8,7 +8,7 @@ import ufl
 
 import fdm
 
-from firedrake_numpy import evaluate_primal, evaluate_pullback, evaluate_jvp
+from firedrake_numpy import evaluate_primal, evaluate_pullback, evaluate_pushforward
 from firedrake_numpy import to_numpy
 
 mesh = fa.UnitSquareMesh(6, 5)
@@ -65,6 +65,9 @@ def test_fenics_jvp():
     fdm_jvp0 = fdm.jvp(ff0, tangents[0])(primals[0])
     fdm_jvp1 = fdm.jvp(ff1, tangents[1])(primals[1])
 
-    _, out_tangent = evaluate_jvp(solve_fenics, templates, primals, tangents)
+    _, fenics_output, fenics_inputs, tape = evaluate_primal(
+        solve_fenics, templates, *inputs
+    )
+    out_tangent = evaluate_pushforward(tangents, fenics_output, fenics_inputs, tape)
 
     assert np.allclose(fdm_jvp0 + fdm_jvp1, out_tangent)

--- a/tests/firedrake_backend/test_assemble.py
+++ b/tests/firedrake_backend/test_assemble.py
@@ -7,7 +7,7 @@ import ufl
 
 import fdm
 
-from firedrake_numpy import evaluate_primal, evaluate_vjp, evaluate_jvp
+from firedrake_numpy import evaluate_primal, evaluate_pullback, evaluate_jvp
 
 
 mesh = firedrake.UnitSquareMesh(3, 2)
@@ -47,7 +47,7 @@ def test_vjp_assemble_eval():
         assemble_firedrake, templates, *inputs
     )
     g = np.ones_like(numpy_output)
-    vjp_out = evaluate_vjp(g, firedrake_output, firedrake_inputs, tape)
+    vjp_out = evaluate_pullback(g, firedrake_output, firedrake_inputs, tape)
 
     fdm_jac0 = fdm.jacobian(ff0)(inputs[0])
     fdm_jac1 = fdm.jacobian(ff1)(inputs[1])

--- a/tests/firedrake_backend/test_assemble.py
+++ b/tests/firedrake_backend/test_assemble.py
@@ -47,7 +47,7 @@ def test_vjp_assemble_eval():
         assemble_firedrake, templates, *inputs
     )
     g = np.ones_like(numpy_output)
-    vjp_out = evaluate_pullback(g, firedrake_output, firedrake_inputs, tape)
+    vjp_out = evaluate_pullback(firedrake_output, firedrake_inputs, tape, g)
 
     fdm_jac0 = fdm.jacobian(ff0)(inputs[0])
     fdm_jac1 = fdm.jacobian(ff1)(inputs[1])
@@ -74,7 +74,7 @@ def test_jvp_assemble_eval():
         assemble_firedrake, templates, *inputs
     )
     out_tangent = evaluate_pushforward(
-        tangents, firedrake_output, firedrake_inputs, tape
+        firedrake_output, firedrake_inputs, tape, tangents
     )
 
     assert np.allclose(fdm_jvp0 + fdm_jvp1 + fdm_jvp2, out_tangent)

--- a/tests/firedrake_backend/test_assemble.py
+++ b/tests/firedrake_backend/test_assemble.py
@@ -7,7 +7,7 @@ import ufl
 
 import fdm
 
-from firedrake_numpy import evaluate_primal, evaluate_pullback, evaluate_jvp
+from firedrake_numpy import evaluate_primal, evaluate_pullback, evaluate_pushforward
 
 
 mesh = firedrake.UnitSquareMesh(3, 2)
@@ -70,6 +70,11 @@ def test_jvp_assemble_eval():
     fdm_jvp1 = fdm.jvp(ff1, tangents[1])(primals[1])
     fdm_jvp2 = fdm.jvp(ff2, tangents[2])(primals[2])
 
-    _, out_tangent = evaluate_jvp(assemble_firedrake, templates, primals, tangents)
+    _, firedrake_output, firedrake_inputs, tape = evaluate_primal(
+        assemble_firedrake, templates, *inputs
+    )
+    out_tangent = evaluate_pushforward(
+        tangents, firedrake_output, firedrake_inputs, tape
+    )
 
     assert np.allclose(fdm_jvp0 + fdm_jvp1 + fdm_jvp2, out_tangent)

--- a/tests/firedrake_backend/test_solve.py
+++ b/tests/firedrake_backend/test_solve.py
@@ -8,7 +8,7 @@ import ufl
 
 import fdm
 
-from firedrake_numpy import evaluate_primal, evaluate_vjp, evaluate_jvp
+from firedrake_numpy import evaluate_primal, evaluate_pullback, evaluate_jvp
 from firedrake_numpy import to_numpy
 
 mesh = firedrake.UnitSquareMesh(6, 5)
@@ -46,7 +46,7 @@ def test_firedrake_vjp():
         solve_firedrake, templates, *inputs
     )
     g = np.ones_like(numpy_output)
-    vjp_out = evaluate_vjp(g, firedrake_output, firedrake_inputs, tape)
+    vjp_out = evaluate_pullback(g, firedrake_output, firedrake_inputs, tape)
     check1 = np.isclose(vjp_out[0], np.asarray(-1.13533304))
     check2 = np.isclose(vjp_out[1], np.asarray(0.94611087))
     assert check1 and check2

--- a/tests/firedrake_backend/test_solve.py
+++ b/tests/firedrake_backend/test_solve.py
@@ -46,7 +46,7 @@ def test_firedrake_vjp():
         solve_firedrake, templates, *inputs
     )
     g = np.ones_like(numpy_output)
-    vjp_out = evaluate_pullback(g, firedrake_output, firedrake_inputs, tape)
+    vjp_out = evaluate_pullback(firedrake_output, firedrake_inputs, tape, g)
     check1 = np.isclose(vjp_out[0], np.asarray(-1.13533304))
     check2 = np.isclose(vjp_out[1], np.asarray(0.94611087))
     assert check1 and check2
@@ -68,7 +68,7 @@ def test_firedrake_jvp():
         solve_firedrake, templates, *inputs
     )
     out_tangent = evaluate_pushforward(
-        tangents, firedrake_output, firedrake_inputs, tape
+        firedrake_output, firedrake_inputs, tape, tangents
     )
 
     assert np.allclose(fdm_jvp0 + fdm_jvp1, out_tangent)

--- a/tests/firedrake_backend/test_solve.py
+++ b/tests/firedrake_backend/test_solve.py
@@ -8,7 +8,7 @@ import ufl
 
 import fdm
 
-from firedrake_numpy import evaluate_primal, evaluate_pullback, evaluate_jvp
+from firedrake_numpy import evaluate_primal, evaluate_pullback, evaluate_pushforward
 from firedrake_numpy import to_numpy
 
 mesh = firedrake.UnitSquareMesh(6, 5)
@@ -64,6 +64,11 @@ def test_firedrake_jvp():
     fdm_jvp0 = fdm.jvp(ff0, tangents[0])(primals[0])
     fdm_jvp1 = fdm.jvp(ff1, tangents[1])(primals[1])
 
-    _, out_tangent = evaluate_jvp(solve_firedrake, templates, primals, tangents)
+    _, firedrake_output, firedrake_inputs, tape = evaluate_primal(
+        solve_firedrake, templates, *inputs
+    )
+    out_tangent = evaluate_pushforward(
+        tangents, firedrake_output, firedrake_inputs, tape
+    )
 
     assert np.allclose(fdm_jvp0 + fdm_jvp1, out_tangent)


### PR DESCRIPTION
JVP and VJP names are too short and it's easy to confuse them, therefore I decided to raname them to pushforward and pullback.

In addition, I changed `evaluate_pushforward` to do what its name says and not do the fused primal computation.