### PR TITLE
Remove numpy.float64 dtype restriction

### DIFF
--- a/fecr/_backends.py
+++ b/fecr/_backends.py
@@ -244,7 +244,11 @@ class FiredrakeBackend(AbstractBackend):
                 return type(firedrake_var_template)(numpy_array)
 
         if isinstance(firedrake_var_template, self.firedrake.Function):
-            u = firedrake_var_template.copy(deepcopy=True)
+            function_space = firedrake_var_template.function_space()
+
+            u = type(firedrake_var_template)(
+                function_space, dtype=firedrake_var_template.dat.dtype
+            )
 
             # assume that given numpy array is global array that needs to be distrubuted across processes
             # when Firedrake function is created


### PR DESCRIPTION
Previously it was hardcoded that we do the conversion only with `numpy.float64` dtype. Now it's just that type of the template function and provided NumPy array should match and dtype check is deferred to PyOP2.

It helps with https://github.com/IvanYashchuk/fecr/issues/14, we still need CI with a build of PETSc with complex numbers support.