### PR TITLE
Numpy 2+ support 

### DIFF
--- a/.github/workflows/ci-fenics.yml
+++ b/.github/workflows/ci-fenics.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Send coveralls
         shell: bash -l {0}
         env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           conda activate fenicsproject
           coveralls

--- a/.github/workflows/ci-fenics.yml
+++ b/.github/workflows/ci-fenics.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
   pull_request:
+  workflow_dispatch:
 
 jobs:
 
@@ -17,10 +18,10 @@ jobs:
           fetch-depth: 2
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
-          python-version: 3.8
+          python-version: 3.12
 
       - name: Conda info
         shell: bash -l {0}
@@ -67,7 +68,7 @@ jobs:
       - name: Send coveralls
         shell: bash -l {0}
         env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           conda activate fenicsproject
           coveralls

--- a/.github/workflows/ci-fenics.yml
+++ b/.github/workflows/ci-fenics.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 2
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
           python-version: 3.10

--- a/.github/workflows/ci-fenics.yml
+++ b/.github/workflows/ci-fenics.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
   pull_request:
+  workflow_dispatch:
 
 jobs:
 
@@ -20,7 +21,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
-          python-version: 3.8
+          python-version: 3.10
 
       - name: Conda info
         shell: bash -l {0}

--- a/.github/workflows/ci-fenics.yml
+++ b/.github/workflows/ci-fenics.yml
@@ -21,7 +21,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
-          python-version: 3.10
+          python-version: 3.8
 
       - name: Conda info
         shell: bash -l {0}

--- a/.github/workflows/ci-fenics.yml
+++ b/.github/workflows/ci-fenics.yml
@@ -21,7 +21,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
-          python-version: 3.8
+          python-version: 3.12
 
       - name: Conda info
         shell: bash -l {0}

--- a/fecr/_backends.py
+++ b/fecr/_backends.py
@@ -166,9 +166,9 @@ class FenicsBackend(AbstractBackend):
                 )
                 raise ValueError(err_msg)
 
-            if numpy_array.dtype != np.float_:
+            if numpy_array.dtype != np.float64:
                 err_msg = (
-                    f"The numpy array must be of type {np.float_}, "
+                    f"The numpy array must be of type {np.float64}, "
                     "but got {numpy_array.dtype}"
                 )
                 raise ValueError(err_msg)


### PR DESCRIPTION
Hi there - While trying to get jax-fenics-adjoint working with the newest version of JAX, I noticed that the fecr fenics backend tests were failing with numpy 2, because `float_` was renamed to `np.float64` -  https://numpy.org/devdocs/numpy_2_0_migration_guide.html 

The firedrake tests are still failing but I see you already opened an issue for that. 